### PR TITLE
Fix widht typo in AssigneesSetter sx prop

### DIFF
--- a/client/src/components/assigneesSetter/AssigneesSetter.tsx
+++ b/client/src/components/assigneesSetter/AssigneesSetter.tsx
@@ -167,7 +167,7 @@ export default function AssigneesSetter({
       }}
       renderInput={(params) => (
         <TextField
-          sx={{ margin: 0, widht: 'inherit' }}
+          sx={{ margin: 0, width: 'inherit' }}
           {...params}
           InputProps={{
             ...params.InputProps


### PR DESCRIPTION
## Summary
Corrects an invalid MUI `sx` property key in `AssigneesSetter`.

The `TextField`'s `sx` used `widht: 'inherit'` — an unrecognized key that MUI silently ignores, so the intended `width: 'inherit'` was never applied. Fixed the key to `width`.

## Change
- [AssigneesSetter.tsx:170](client/src/components/assigneesSetter/AssigneesSetter.tsx#L170): `widht` → `width`

## Risk
Minimal — one-line, styling-only fix. Restores the intended inherited width on the assignee input.