### PR TITLE
Remove stray console.log and tidy small frontend inconsistencies

### DIFF
--- a/client/src/components/assigneesSetter/AssigneesSetter.tsx
+++ b/client/src/components/assigneesSetter/AssigneesSetter.tsx
@@ -37,7 +37,7 @@ export default function AssigneesSetter({
     string[]
   >([]);
   const [loading, setLoading] = React.useState(false);
-  const isNewIssue = issueId ? false : true;
+  const isNewIssue = !issueId;
 
   React.useEffect(() => {
     return delayExec(async () => {

--- a/client/src/components/issueProgress/IssueProgressSelect.tsx
+++ b/client/src/components/issueProgress/IssueProgressSelect.tsx
@@ -27,7 +27,7 @@ function IssueProgressSelect({
 
   const update = (e: any) => {
     const value = e.target.value;
-    setValue(e.target.value);
+    setValue(value);
     if (onChange) {
       if (value === IssueProgress.Unspecified) {
         onChange(undefined);

--- a/client/src/components/projectProgress/ProjectProgressSelect.tsx
+++ b/client/src/components/projectProgress/ProjectProgressSelect.tsx
@@ -34,7 +34,6 @@ function ProjectProgressSelect({
         onChange(undefined);
       } else {
         onChange(value);
-        console.log(value);
       }
     }
   };


### PR DESCRIPTION
- Drop leftover debug console.log in ProjectProgressSelect
- Use the destructured value in IssueProgressSelect.setValue, matching sibling selects
- Simplify isNewIssue to a negation in AssigneesSetter