### PR TITLE
Fix Kanban card ordering not persisting across reloads

### DIFF
--- a/client/src/components/kanban/Kanban.jsx
+++ b/client/src/components/kanban/Kanban.jsx
@@ -52,7 +52,7 @@ const Kanban = ({ cards }) => {
           .map((progressStatus) => {
             const sortedCards = cards
               .filter((x) => x.progress === progressStatus.value)
-              .sort((x) => x.position)
+              .sort((a, b) => a.position - b.position)
               .map((p) => ({
                 id: p.id,
                 projectId: p.projectId,

--- a/client/src/models/kanbanCard/kanbanCard.ts
+++ b/client/src/models/kanbanCard/kanbanCard.ts
@@ -5,6 +5,7 @@ import { IssueType } from '@/models/issue/issueType';
 export type KanbanCard = {
   id: string;
   projectId: string;
+  position: number;
   summary: string;
   type: IssueType;
   progress: IssueProgress;

--- a/server/src/IssueTracker.Application/Mappings/Issues/IssueToKanbanCardVm.cs
+++ b/server/src/IssueTracker.Application/Mappings/Issues/IssueToKanbanCardVm.cs
@@ -8,7 +8,7 @@ public class IssueToKanbanCardVm : Profile
     public IssueToKanbanCardVm()
     {
         CreateMap<Issue, KanbanCardVm>()
-            .ForMember(dest => dest.ProjectId, cfg => cfg.MapFrom(src => src.Project.Id))
+            .ForMember(dest => dest.ProjectId, cfg => cfg.MapFrom(src => src.ProjectId))
             .ForMember(dest => dest.Position,
                 cfg => cfg.MapFrom(src => src.Permissions.Single().KanbanRowPosition));
     }


### PR DESCRIPTION
The board persists each card's KanbanRowPosition on drag, but the saved order was never restored:

- Kanban.jsx used an invalid single-arg sort comparator (.sort((x) => x.position)) that does not order by position, so cards rendered in response order regardless of their saved position.
- The UpdateIssueKanban response mapped ProjectId from src.Project.Id, but that handler doesn't Include(Project) (unlike the read query), so after a drag every returned card had a null ProjectId. Map ProjectId from the scalar FK (src.ProjectId) instead, which is always populated and fixes both paths without an extra join.
- Add the real 'position' field to the KanbanCard TS model.