### PR TITLE
Clean up small warnings and a render side-effect

### DIFF
--- a/client/src/features/issue/details/Comments.tsx
+++ b/client/src/features/issue/details/Comments.tsx
@@ -75,6 +75,7 @@ function IssueDetailsComments({ permissions }: Props) {
 
         {comments?.map((comment) => (
           <Comment
+            key={comment.id}
             comment={comment}
             onCommentStateChanged={handleCommentStateChanged}
           />

--- a/client/src/features/login/SigningPage.tsx
+++ b/client/src/features/login/SigningPage.tsx
@@ -1,9 +1,15 @@
+import { useEffect } from 'react';
 import { useAuth } from '@/authentication/Auth';
 import LoadingPage from '@/layout/common/LoadingPage';
 
 function SigningInPage() {
   const { signIn } = useAuth();
-  signIn();
+
+  useEffect(() => {
+    signIn();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return <LoadingPage />;
 }
 

--- a/server/src/IssueTracker.Infrastructure/Services/AppDbContext/AppDbContext.cs
+++ b/server/src/IssueTracker.Infrastructure/Services/AppDbContext/AppDbContext.cs
@@ -1,6 +1,5 @@
 ﻿using IssueTracker.Application.Utils;
 using IssueTracker.Application.Interfaces;
-using IssueTracker.Application.Interfaces;
 using IssueTracker.Domain.Models;
 using IssueTracker.Domain.Models.Enums;
 using Microsoft.EntityFrameworkCore;

--- a/server/tests/IntegrationTests/IssueTracker.IntegrationTests/Helpers/WebHost.cs
+++ b/server/tests/IntegrationTests/IssueTracker.IntegrationTests/Helpers/WebHost.cs
@@ -1,5 +1,4 @@
 ﻿using IssueTracker.Application.Interfaces;
-using IssueTracker.Application.Interfaces;
 using IssueTracker.Infrastructure.Services.AppDbContext;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;


### PR DESCRIPTION
- Remove duplicate 'using IssueTracker.Application.Interfaces' in AppDbContext and WebHost (silences two CS0105 warnings)
- Add missing React key to the comments list in Comments.tsx
- Call signIn() from a useEffect in SigningPage instead of during render, avoiding a side-effect on render (double-invoked under StrictMode)